### PR TITLE
Fix Repository Syntax in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Backend collector of client tracking data",
   "main": "server.js",
   "scripts": {},
-  "repository": "https://github.com/ibm-cds-labs/metrics-collector",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ibm-cds-labs/metrics-collector"
+  },
   "keywords": [
     "tracking"
   ],


### PR DESCRIPTION
This pull requests fixes the syntax for the `repository` field in `package.json` and fixes #8.